### PR TITLE
[22] call pack_struct instead of deprecated packStruct

### DIFF
--- a/api/lib/readAggInfo.cpp
+++ b/api/lib/readAggInfo.cpp
@@ -42,8 +42,8 @@ readAggInfo( rsComm_t*     rsComm,
                       "readAggInfo: rsDataObjGet error for %s", dataObjInp.objPath );
         return status;
     }
-    status = unpackStruct( packedBBuf.buf, ( void ** ) ncAggInfo,
-                           "NcAggInfo_PI", RodsPackTable, XML_PROT );
+    status = unpack_struct( packedBBuf.buf, ( void ** ) ncAggInfo,
+                            "NcAggInfo_PI", RodsPackTable, XML_PROT, nullptr );
 
     if ( status < 0 ) {
         rodsLogError( LOG_ERROR, status,

--- a/api/src/rsNcGetAggInfo.cpp
+++ b/api/src/rsNcGetAggInfo.cpp
@@ -97,8 +97,8 @@ extern "C" {
         if ( status >= 0 && ( ncOpenInp->mode & NC_WRITE ) != 0 ) {
             dataObjInp_t dataObjInp;
             portalOprOut_t *portalOprOut = NULL;
-            status = packStruct( ( void * ) * ncAggInfo, &packedBBuf, "NcAggInfo_PI",
-                                 RodsPackTable, 0, XML_PROT );
+            status = pack_struct( ( void * ) * ncAggInfo, &packedBBuf, "NcAggInfo_PI",
+                                  RodsPackTable, 0, XML_PROT, nullptr );
             if ( status < 0 ) {
                 rodsLogError( LOG_ERROR, status,
                               "rsNcGetAggInfo: packStruct error for %s",


### PR DESCRIPTION
Correspondingly, an unpackStruct call was  replaced with unpack_struct.
The plugins now build without error or warning.