### PR TITLE
[irods/irods#6251] do not explicitly add fmt to includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,6 @@ foreach (variant IN ITEMS client server)
     # but since we distribute no dev packages, it's easier to put them in PUBLIC
     # and wrap them in BUILD_INTERFACE
     "$<BUILD_INTERFACE:${IRODS_EXTERNALS_FULLPATH_BOOST}/include>"
-    "$<BUILD_INTERFACE:${IRODS_EXTERNALS_FULLPATH_FMT}/include>"
   )
 
   set_target_properties(irods_netcdf_obj_${variant} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)


### PR DESCRIPTION
In service of irods/irods#6251

Ignore the branch name.

Once this is merged, a 4-3-stable branch should be created.